### PR TITLE
Feat add search and filters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     environment:
       - REACT_APP_AUTH0_DOMAIN=${REACT_APP_AUTH0_DOMAIN}
       - REACT_APP_AUTH0_CLIENT_ID=${REACT_APP_AUTH0_CLIENT_ID}
+      - REACT_APP_API_URL=http://localhost:8080/api
     depends_on:
       - backend
     networks:

--- a/frontend/__mocks__/fileMock.js
+++ b/frontend/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub'; 

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  roots: ['<rootDir>/src'],
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+    '\\.(gif|ttf|eot|svg)$': '<rootDir>/__mocks__/fileMock.js',
+  },
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/index.tsx',
+    '!src/reportWebVitals.ts',
+  ],
+}; 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import ButtonAppBar from './components/AppBar/ButtonAppBar';
 import Home from './pages/Home/Home';
-import CollectionPage from './pages/CollectionPage/CollectionPage';
 import StatsPage from './pages/StatsPage/StatsPage';
 import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
+import Collection from './pages/Collection/Collection';
 
 const App: React.FC = () => {
   return (
@@ -16,7 +16,7 @@ const App: React.FC = () => {
           path="/collection" 
           element={
           <ProtectedRoute>
-            <CollectionPage />
+            <Collection />
           </ProtectedRoute>
         } />
         <Route 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -6,9 +6,6 @@ import CssBaseline from '@mui/material/CssBaseline';
 import App from './App';
 import theme from './theme';
 
-console.log('REACT_APP_AUTH0_DOMAIN:', process.env.REACT_APP_AUTH0_DOMAIN);
-console.log('REACT_APP_AUTH0_CLIENT_ID:', process.env.REACT_APP_AUTH0_CLIENT_ID);
-
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
 root.render(

--- a/frontend/src/pages/Collection/Collection.test.tsx
+++ b/frontend/src/pages/Collection/Collection.test.tsx
@@ -1,0 +1,226 @@
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import theme from '../../theme';
+import Collection from './Collection';
+import api from '../../services/api';
+
+// Mock API
+jest.mock('../../services/api', () => ({
+  get: jest.fn(),
+  defaults: {
+    headers: {
+      common: {}
+    }
+  }
+}));
+
+describe('Collection Component', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.clearAllMocks();
+    
+    // Setup API mock response
+    (api.get as jest.Mock).mockResolvedValue({
+      data: {
+        books: [
+          { ID: 1, title: 'Harry Potter', author: 'J.K. Rowling', genre: 'Fantasy', rating: 4.5, page_count: 300 },
+          { ID: 2, title: '1984', author: 'George Orwell', genre: 'Science Fiction', rating: 5, page_count: 400 },
+        ]
+      }
+    });
+
+    // Debug: Log when beforeEach runs
+    console.log('beforeEach: Fresh component and mocks');
+  });
+
+  afterEach(() => {
+    // Debug: Log when cleanup happens
+    console.log('afterEach: Cleaning up');
+  });
+
+  const renderComponent = () => {
+    const result = render(
+      <ThemeProvider theme={theme}>
+        <BrowserRouter>
+          <Collection />
+        </BrowserRouter>
+      </ThemeProvider>
+    );
+    // Debug: Log when component is rendered
+    console.log('Component rendered');
+    return result;
+  };
+
+  test('displays books after loading', async () => {
+    renderComponent();
+
+    // Wait for the API call to be made
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith('/books/collection', expect.any(Object));
+    });
+
+    // Wait for books to appear and verify they're displayed
+    await waitFor(() => {
+      expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+      expect(screen.getByText('1984')).toBeInTheDocument();
+    });
+  });
+
+  test('filters books by search query', async () => {
+    renderComponent();
+
+    // Wait for books to load
+    await waitFor(() => {
+      expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+    });
+
+    // Find and use the search input
+    const searchInput = screen.getByPlaceholderText('Search by title or author...');
+    fireEvent.change(searchInput, { target: { value: 'Harry' } });
+
+    // Verify filtered results
+    expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+    expect(screen.queryByText('1984')).not.toBeInTheDocument();
+
+    // Clear search
+    fireEvent.change(searchInput, { target: { value: '' } });
+    expect(screen.getByText('1984')).toBeInTheDocument();
+  });
+
+  test('filters books by genre', async () => {
+    renderComponent();
+
+    // Wait for books to load
+    await waitFor(() => {
+      expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+    });
+
+    // Open filters
+    fireEvent.click(screen.getByRole('button', { name: /show filters/i }));
+
+    // Find and click the genre combobox
+    const combobox = await waitFor(() => screen.getByRole('combobox'));
+    fireEvent.mouseDown(combobox);
+
+    // Wait for listbox to be visible and select Fantasy
+    const listbox = await screen.findByRole('listbox');
+    const fantasyOption = within(listbox).getByText(/fantasy/i);
+    fireEvent.click(fantasyOption);
+
+    // Verify filtered results
+    await waitFor(() => {
+      expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+      expect(screen.queryByText('1984')).not.toBeInTheDocument();
+    });
+  });
+
+  test('filters books by minimum rating', async () => {
+    renderComponent();
+
+    // Wait for books to load
+    await waitFor(() => {
+      expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+    });
+
+    // Open filters
+    fireEvent.click(screen.getByRole('button', { name: /show filters/i }));
+
+    // Find the rating component
+    const ratingLabel = await waitFor(() => screen.getByText('Minimum Rating'));
+    
+    // Find the 5-star radio input by its value
+    const fiveStarInput = screen.getByRole('radio', { name: '5 Stars' });
+    fireEvent.click(fiveStarInput);
+
+    // Wait for filter to be applied
+    await waitFor(() => {
+      expect(screen.queryByText('Harry Potter')).not.toBeInTheDocument();
+      expect(screen.getByText('1984')).toBeInTheDocument();
+    }, { timeout: 2000 });
+  });
+
+  test('clears all filters when reset button is clicked', async () => {
+    renderComponent();
+
+    // Wait for books to load
+    await waitFor(() => {
+      expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+    });
+
+    // Open filters
+    fireEvent.click(screen.getByText('Show Filters'));
+
+    // Apply search filter
+    const searchInput = screen.getByPlaceholderText('Search by title or author...');
+    fireEvent.change(searchInput, { target: { value: 'Harry' } });
+
+    // Verify filter is applied
+    expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+    expect(screen.queryByText('1984')).not.toBeInTheDocument();
+
+    // Clear filters
+    fireEvent.click(screen.getByText('Clear Filters'));
+
+    // Verify all books are shown
+    expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+    expect(screen.getByText('1984')).toBeInTheDocument();
+    expect(searchInput).toHaveValue('');
+  });
+
+  test('shows correct results count', async () => {
+    renderComponent();
+
+    // Wait for books to load
+    await waitFor(() => {
+      expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+    });
+
+    // Check initial count
+    expect(screen.getByText('Showing 2 of 2 books')).toBeInTheDocument();
+
+    // Apply search filter
+    const searchInput = screen.getByPlaceholderText('Search by title or author...');
+    fireEvent.change(searchInput, { target: { value: 'Harry' } });
+
+    // Check updated count
+    expect(screen.getByText('Showing 1 of 2 books')).toBeInTheDocument();
+  });
+
+  test('filters books by page count range', async () => {
+    renderComponent();
+
+    // Wait for books to load
+    await waitFor(() => {
+      expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+    });
+
+    // Open filters
+    fireEvent.click(screen.getByRole('button', { name: /show filters/i }));
+
+    // Find the page count slider inputs
+    const sliderInputs = screen.getAllByRole('slider');
+    const minInput = sliderInputs[0];  // First input is min
+    const maxInput = sliderInputs[1];  // Second input is max
+
+    // Set range to 350-450 pages (should only show 1984 which has 400 pages)
+    fireEvent.change(minInput, { target: { value: 350 } });
+    fireEvent.change(maxInput, { target: { value: 450 } });
+
+    // Verify filtered results
+    await waitFor(() => {
+      expect(screen.queryByText('Harry Potter')).not.toBeInTheDocument(); // 300 pages
+      expect(screen.getByText('1984')).toBeInTheDocument(); // 400 pages
+    });
+
+    // Reset to show all books
+    fireEvent.change(minInput, { target: { value: 0 } });
+    fireEvent.change(maxInput, { target: { value: 2000 } });
+
+    // Verify all books are shown
+    await waitFor(() => {
+      expect(screen.getByText('Harry Potter')).toBeInTheDocument();
+      expect(screen.getByText('1984')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/Collection/Collection.tsx
+++ b/frontend/src/pages/Collection/Collection.tsx
@@ -1,0 +1,262 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Container,
+  Box,
+  Typography,
+  TextField,
+  Paper,
+  Slider,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Chip,
+  IconButton,
+  InputAdornment,
+  Rating,
+  Collapse,
+  Button,
+  Grid2,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import ClearIcon from '@mui/icons-material/Clear';
+import { useAuth0 } from '@auth0/auth0-react';
+import DeleteBookCard from '../../components/BookCard/DeleteBookCard';
+import { Book } from '../../types/book';
+import api from '../../services/api';
+import { genres } from '../../components/ManualBookEntry/genres';
+
+const Collection: React.FC = () => {
+const { getAccessTokenSilently, isAuthenticated } = useAuth0();
+  const [books, setBooks] = useState<Book[]>([]);
+  const [filteredBooks, setFilteredBooks] = useState<Book[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showFilters, setShowFilters] = useState(false);
+  
+  // Search and Filter States
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
+  const [ratingFilter, setRatingFilter] = useState<number>(0);
+  const [pageCountRange, setPageCountRange] = useState<number[]>([0, 2000]);
+
+  // Fetch books from API
+  useEffect(() => {
+    const fetchBooks = async () => {
+      try {
+        const token = await getAccessTokenSilently();
+        const response = await api.get('/books/collection', {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        
+        // Ensure we have an array of books
+        const booksData = Array.isArray(response.data.books) ? response.data.books : [];
+        setBooks(booksData);
+        setFilteredBooks(booksData);
+      } catch (error) {
+        console.error('Error fetching books:', error);
+        setBooks([]);
+        setFilteredBooks([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBooks();
+  }, [getAccessTokenSilently]);
+
+  // Apply filters
+  useEffect(() => {
+    if (!Array.isArray(books)) {
+      console.error('Books data is not an array:', books);
+      setFilteredBooks([]);
+      return;
+    }
+
+    let result = [...books];
+
+    // Search filter
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      result = result.filter(book => 
+        book?.title?.toLowerCase().includes(query) ||
+        book?.author?.toLowerCase().includes(query)
+      );
+    }
+
+    // Genre filter
+    if (selectedGenres.length > 0) {
+      result = result.filter(book => book?.genre && selectedGenres.includes(book.genre));
+    }
+
+    // Rating filter
+    if (ratingFilter > 0) {
+      result = result.filter(book => (book?.rating || 0) >= ratingFilter);
+    }
+
+    // Page count filter
+    result = result.filter(book => 
+      (book?.page_count || 0) >= pageCountRange[0] && 
+      (book?.page_count || 0) <= pageCountRange[1]
+    );
+
+    setFilteredBooks(result);
+  }, [books, searchQuery, selectedGenres, ratingFilter, pageCountRange]);
+
+  const handleGenreChange = (event: any) => {
+    const value = event.target.value;
+    setSelectedGenres(typeof value === 'string' ? value.split(',') : value);
+  };
+
+  const handleClearFilters = () => {
+    setSearchQuery('');
+    setSelectedGenres([]);
+    setRatingFilter(0);
+    setPageCountRange([0, 2000]);
+  };
+
+  return (
+    <Container maxWidth="lg">
+      <Box sx={{ py: 4 }}>
+        <Box sx={{ mb: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Your Collection
+          </Typography>
+          <Button
+            startIcon={<FilterListIcon />}
+            onClick={() => setShowFilters(!showFilters)}
+            color="primary"
+          >
+            {showFilters ? 'Hide Filters' : 'Show Filters'}
+          </Button>
+        </Box>
+
+        {/* Search and Filters */}
+        <Paper sx={{ mb: 4, p: 2 }}>
+          <Grid2 container spacing={2}>
+            <Grid2 size={{ xs: 12 }}>
+              <TextField
+                fullWidth
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search by title or author..."
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon />
+                    </InputAdornment>
+                  ),
+                  endAdornment: searchQuery && (
+                    <InputAdornment position="end">
+                      <IconButton size="small" onClick={() => setSearchQuery('')}>
+                        <ClearIcon />
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
+              />
+            </Grid2>
+
+            <Collapse in={showFilters} sx={{ width: '100%' }}>
+              <Grid2 container spacing={2} sx={{ mt: 1 }}>
+                <Grid2 size={{ xs: 12, md: 4 }}>
+                  <FormControl fullWidth>
+                    <InputLabel>Genres</InputLabel>
+                    <Select
+                      multiple
+                      value={selectedGenres}
+                      onChange={handleGenreChange}
+                      label="Genres"
+                      renderValue={(selected) => (
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                          {selected.map((value) => (
+                            <Chip key={value} label={value} size="small" />
+                          ))}
+                        </Box>
+                      )}
+                    >
+                      {genres.map((genre) => (
+                        <MenuItem key={genre} value={genre}>
+                          {genre}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </Grid2>
+
+                <Grid2 size={{ xs: 12, md: 4 }}>
+                  <Box sx={{ px: 2 }}>
+                    <Typography gutterBottom>Minimum Rating</Typography>
+                    <Rating
+                      value={ratingFilter}
+                      onChange={(_, newValue) => setRatingFilter(newValue || 0)}
+                      precision={0.5}
+                    />
+                  </Box>
+                </Grid2>
+
+                <Grid2 size={{ xs: 12, md: 4 }}>
+                  <Box sx={{ px: 2 }}>
+                    <Typography gutterBottom>Page Count Range</Typography>
+                    <Slider
+                      value={pageCountRange}
+                      onChange={(_, newValue) => setPageCountRange(newValue as number[])}
+                      valueLabelDisplay="auto"
+                      min={0}
+                      max={2000}
+                      step={50}
+                    />
+                  </Box>
+                </Grid2>
+
+                <Grid2 size={{ xs: 12 }}>
+                  <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <Button
+                      variant="outlined"
+                      onClick={handleClearFilters}
+                      startIcon={<ClearIcon />}
+                    >
+                      Clear Filters
+                    </Button>
+                  </Box>
+                </Grid2>
+              </Grid2>
+            </Collapse>
+          </Grid2>
+        </Paper>
+
+        {/* Results count */}
+        <Typography variant="subtitle1" sx={{ mb: 2 }}>
+          Showing {filteredBooks.length} of {books.length} books
+        </Typography>
+
+        {/* Book Grid */}
+        <Grid2 container spacing={3}>
+          {filteredBooks.map((book) => (
+            <Grid2 size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={book.ID}>
+              <DeleteBookCard 
+                book={book} 
+                onDeleteSuccess={() => {
+                  setBooks(books.filter(b => b.ID !== book.ID));
+                }} 
+              />
+            </Grid2>
+          ))}
+        </Grid2>
+
+        {/* Empty state */}
+        {filteredBooks.length === 0 && !loading && (
+          <Box sx={{ textAlign: 'center', py: 4 }}>
+            <Typography variant="h6" color="text.secondary">
+              No books found matching your criteria
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    </Container>
+  );
+};
+
+export default Collection; 

--- a/frontend/src/pages/CollectionPage/CollectionPage.tsx
+++ b/frontend/src/pages/CollectionPage/CollectionPage.tsx
@@ -1,19 +1,79 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
-import { Box, Typography, Snackbar } from '@mui/material';
+import { 
+  Box, 
+  Typography, 
+  Snackbar, 
+  Alert, 
+  Container, 
+  Paper,
+  Fade,
+  CircularProgress,
+  InputBase,
+  IconButton,
+  Divider,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import LocalLibraryIcon from '@mui/icons-material/LocalLibrary';
+import { styled } from '@mui/material/styles';
 import api from '../../services/api';
 import DeleteBookCard from '../../components/BookCard/DeleteBookCard';
 import { Book } from '../../types/book';
 
+const HeaderPaper = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(3),
+  marginBottom: theme.spacing(4),
+  background: `linear-gradient(120deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`,
+  color: theme.palette.primary.contrastText,
+  position: 'relative',
+  overflow: 'hidden',
+  '&::after': {
+    content: '""',
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    background: 'linear-gradient(60deg, rgba(255,255,255,0.1) 25%, transparent 25%)',
+    backgroundSize: '20px 20px',
+    zIndex: 1,
+  }
+}));
+
+const SearchBar = styled(Paper)(({ theme }) => ({
+  padding: '2px 4px',
+  display: 'flex',
+  alignItems: 'center',
+  width: '100%',
+  maxWidth: 400,
+  marginBottom: theme.spacing(4),
+  boxShadow: 'none',
+  border: `1px solid ${theme.palette.divider}`,
+  '&:hover': {
+    border: `1px solid ${theme.palette.primary.main}`,
+  },
+}));
+
+const BooksGrid = styled(Box)(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
+  gap: theme.spacing(3),
+  padding: theme.spacing(2),
+  justifyItems: 'center',
+}));
 
 const CollectionPage: React.FC = () => {
-  const { getAccessTokenSilently } = useAuth0();
+  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
   const [books, setBooks] = useState<Book[]>([]);
-  const [error, setError] = useState<string | null>(null);  
+  const [filteredBooks, setFilteredBooks] = useState<Book[]>([]);
+  const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
 
   const fetchCollection = useCallback(async () => {
     try {
+      setLoading(true);
       const token = await getAccessTokenSilently();
       const response = await api.get('/books/collection', {
         headers: {
@@ -25,55 +85,131 @@ const CollectionPage: React.FC = () => {
         ...book,
         id: book.ID,
       }));
-      setBooks(books);
-      setBooks(books.filter((book: Book) => !book.deleted_at));
+      const activeBooks = books.filter((book: Book) => !book.deleted_at);
+      setBooks(activeBooks);
+      setFilteredBooks(activeBooks);
     } catch (err) {
       console.error('Error fetching collection:', err);
       setError('Failed to load your book collection.');
+    } finally {
+      setLoading(false);
     }
   }, [getAccessTokenSilently]);
 
   useEffect(() => {
-    fetchCollection();
-  }, [fetchCollection]);
+    if (isAuthenticated) {
+      fetchCollection();
+    }
+  }, [fetchCollection, isAuthenticated]);
+
+  const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const query = event.target.value.toLowerCase();
+    setSearchQuery(query);
+    
+    const filtered = books.filter(book => 
+      book.title.toLowerCase().includes(query) ||
+      book.author.toLowerCase().includes(query) ||
+      (book.genre && book.genre.toLowerCase().includes(query))
+    );
+    setFilteredBooks(filtered);
+  };
+
+  if (!isAuthenticated) {
+    return (
+      <Container maxWidth="lg">
+        <HeaderPaper elevation={3}>
+          <Typography variant="h5" gutterBottom>
+            Welcome to Your Book Collection
+          </Typography>
+          <Typography variant="body1">
+            Please log in to view and manage your books.
+          </Typography>
+        </HeaderPaper>
+      </Container>
+    );
+  }
 
   return (
-    <Box sx={{ mt: 4 }}>
-      <Typography variant="h4" gutterBottom>
-        Your Book Collection
-      </Typography>
+    <Container maxWidth="lg">
+      <Fade in timeout={800}>
+        <Box>
+          <HeaderPaper elevation={3}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+              <LocalLibraryIcon sx={{ fontSize: 40 }} />
+              <Typography variant="h4" component="h1">
+                Your Book Collection
+              </Typography>
+            </Box>
+            <Typography variant="subtitle1">
+              {books.length} {books.length === 1 ? 'book' : 'books'} in your library
+            </Typography>
+          </HeaderPaper>
 
-      {books.length > 0 ? (
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center' }}>
-          {books.map((book) => (
-            <DeleteBookCard
-              key={book.ID}
-              book={book}
-              onDeleteSuccess={fetchCollection}
+          <SearchBar>
+            <IconButton sx={{ p: '10px' }} aria-label="search">
+              <SearchIcon />
+            </IconButton>
+            <InputBase
+              sx={{ ml: 1, flex: 1 }}
+              placeholder="Search by title, author, or genre..."
+              value={searchQuery}
+              onChange={handleSearch}
             />
-          ))}
-        </Box>
-      ) : (
-        <Typography variant="body1">You have no books in your collection.</Typography>
-      )}
+          </SearchBar>
 
-      {error && (
-        <Snackbar
-          open={!!error}
-          autoHideDuration={6000}
-          onClose={() => setError(null)}
-          message={error}
-        />
-      )}
-      {success && (
-        <Snackbar
-          open={!!success}
-          autoHideDuration={6000}
-          onClose={() => setSuccess(null)}
-          message={success}
-        />
-      )}
-    </Box>
+          {loading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+              <CircularProgress />
+            </Box>
+          ) : filteredBooks.length > 0 ? (
+            <Fade in timeout={500}>
+              <BooksGrid>
+                {filteredBooks.map((book) => (
+                  <DeleteBookCard
+                    key={book.ID}
+                    book={book}
+                    onDeleteSuccess={fetchCollection}
+                  />
+                ))}
+              </BooksGrid>
+            </Fade>
+          ) : (
+            <Paper sx={{ p: 4, textAlign: 'center' }}>
+              <Typography variant="h6" color="text.secondary" gutterBottom>
+                {searchQuery ? 'No books match your search' : 'Your collection is empty'}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {searchQuery 
+                  ? 'Try adjusting your search terms'
+                  : 'Add some books to get started!'
+                }
+              </Typography>
+            </Paper>
+          )}
+        </Box>
+      </Fade>
+
+      <Snackbar
+        open={!!error}
+        autoHideDuration={6000}
+        onClose={() => setError(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setError(null)} severity="error" variant="filled">
+          {error}
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={!!success}
+        autoHideDuration={6000}
+        onClose={() => setSuccess(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setSuccess(null)} severity="success" variant="filled">
+          {success}
+        </Alert>
+      </Snackbar>
+    </Container>
   );
 };
 

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -3,3 +3,40 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+// Mock Auth0
+const mockGetAccessTokenSilently = jest.fn().mockResolvedValue('test-token');
+jest.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => ({
+    isAuthenticated: true,
+    getAccessTokenSilently: mockGetAccessTokenSilently,
+  }),
+}));
+
+// Mock axios
+jest.mock('axios', () => ({
+  create: jest.fn(() => ({
+    get: jest.fn(),
+    post: jest.fn(),
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  })),
+}));
+
+// Add TextEncoder/TextDecoder to global
+Object.assign(global, {
+  TextEncoder: TextEncoder,
+  TextDecoder: TextDecoder,
+});
+
+// Suppress act() warning
+const originalError = console.error;
+console.error = (...args) => {
+  if (args[0].includes('Warning: `ReactDOMTestUtils.act` is deprecated')) {
+    return;
+  }
+  originalError.call(console, ...args);
+};


### PR DESCRIPTION
# Closes #7 

## Description
Added search and filter functionality to the Collection page, including:
- Query Search
- Genre filter
- Rating filter
- Page count range filter

## Changes Made
- Added search bar with real-time filtering
- Implemented multi-select genre filter
- Added rating filter with star selection
- Added page count range slider
- Added filter toggle button
- Implemented filter state management

## Testing
Manually tested the following scenarios:
- [x] Search filters books by title and author correctly
- [x] Genre filter shows only books of selected genres
- [x] Rating filter shows books with rating >= selected value
- [x] Page count filter shows books within selected range
- [x] Multiple filters work together correctly
- [x] Clear filters button resets all filters
- [x] UI remains responsive on mobile and desktop views