### PR TITLE
feat: add subscription and development notice modals

### DIFF
--- a/frontend/src/components/DevelopmentModals/DevelopmentNoticeModal.test.js
+++ b/frontend/src/components/DevelopmentModals/DevelopmentNoticeModal.test.js
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import DevelopmentNoticeModal from './DevelopmentNoticeModal';
+
+describe('DevelopmentNoticeModal', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('renders the modal and closes on button click', () => {
+    render(<DevelopmentNoticeModal />);
+
+    // Check if the modal is open and contains the correct text
+    expect(screen.getByText(/Site Under Development/i)).toBeInTheDocument();
+    expect(screen.getByText(/This site is currently under development/i)).toBeInTheDocument();
+
+    // Click the "I Understand" button
+    fireEvent.click(screen.getByText(/I Understand/i));
+
+    // Check if the modal is closed
+    expect(screen.queryByText(/Site Under Development/i)).not.toBeInTheDocument();
+  });
+
+  test('sets localStorage after closing', () => {
+    render(<DevelopmentNoticeModal />);
+
+    // Click the "I Understand" button
+    fireEvent.click(screen.getByText(/I Understand/i));
+
+    // Check if localStorage is set
+    expect(localStorage.getItem('hasSeenDevelopmentNotice')).toBe('true');
+  });
+});

--- a/frontend/src/components/DevelopmentModals/DevelopmentNoticeModal.tsx
+++ b/frontend/src/components/DevelopmentModals/DevelopmentNoticeModal.tsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import { Modal, Box, Typography, Button } from '@mui/material';
+
+const DevelopmentNoticeModal = () => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const hasSeenNotice = localStorage.getItem('hasSeenDevelopmentNotice');
+    if (!hasSeenNotice) {
+      setOpen(true);
+    }
+  }, []);
+
+  const handleClose = () => {
+    localStorage.setItem('hasSeenDevelopmentNotice', 'true');
+    setOpen(false);
+  };
+
+  return (
+    <Modal open={open} onClose={handleClose}>
+      <Box
+        sx={{
+          p: 4,
+          backgroundColor: 'background.paper',
+          borderRadius: 2,
+          maxWidth: 400,
+          mx: 'auto',
+          mt: '20%',
+          boxShadow: 3,
+          textAlign: 'center',
+        }}
+      >
+        <Typography variant="h6" gutterBottom color="primary">
+          Site Under Development
+        </Typography>
+        <Typography variant="body1" sx={{ mb: 2, color: 'text.secondary' }}>
+          This site is currently under development. Features and data are subject to change, and data may be wiped.
+        </Typography>
+        <Button variant="contained" color="primary" onClick={handleClose}>
+          I Understand
+        </Button>
+      </Box>
+    </Modal>
+  );
+};
+
+export default DevelopmentNoticeModal;

--- a/frontend/src/components/DevelopmentModals/SubscriptionNoticeModal.test.js
+++ b/frontend/src/components/DevelopmentModals/SubscriptionNoticeModal.test.js
@@ -1,0 +1,18 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SubscriptionNoticeModal from './SubscriptionNoticeModal';
+
+describe('SubscriptionNoticeModal', () => {
+  test('renders the modal and closes on button click', () => {
+    render(<SubscriptionNoticeModal />);
+
+    // Check if the modal is open and contains the correct text
+    expect(screen.getByText(/Subscription Notice/i)).toBeInTheDocument();
+    expect(screen.getByText(/During development, you will not be charged/i)).toBeInTheDocument();
+
+    // Click the "I Understand" button
+    fireEvent.click(screen.getByText(/I Understand/i));
+
+    // Check if the modal is closed
+    expect(screen.queryByText(/Subscription Notice/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/DevelopmentModals/SubscriptionNoticeModal.tsx
+++ b/frontend/src/components/DevelopmentModals/SubscriptionNoticeModal.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { Modal, Box, Typography, Button } from '@mui/material';
+
+const SubscriptionNoticeModal = () => {
+  const [open, setOpen] = useState(true);
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <Modal open={open} onClose={handleClose}>
+      <Box
+        sx={{
+          p: 4,
+          backgroundColor: 'background.paper',
+          borderRadius: 2,
+          maxWidth: 400,
+          mx: 'auto',
+          mt: '20%',
+          boxShadow: 3,
+          textAlign: 'center',
+        }}
+      >
+        <Typography variant="h6" gutterBottom color="primary">
+          Subscription Notice
+        </Typography>
+        <Typography variant="body1" sx={{ mb: 2, color: 'text.secondary' }}>
+          During development, you will not be charged for subscriptions. Please use the test card 4242 4242 4242 4242 with expiry 12/34 and CVC 567.
+        </Typography>
+        <Button variant="contained" color="primary" onClick={handleClose}>
+          I Understand
+        </Button>
+      </Box>
+    </Modal>
+  );
+};
+
+export default SubscriptionNoticeModal;

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -9,6 +9,7 @@ import { styled } from '@mui/material/styles';
 import ManualBookEntry from '../../components/ManualBookEntry/ManualBookEntry';
 import { useNavigate } from 'react-router-dom';
 import { Bar, Pie } from 'react-chartjs-2';
+import DevelopmentNoticeModal from '../../components/DevelopmentModals/DevelopmentNoticeModal';
 
 const HeroSection = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(8),
@@ -81,6 +82,7 @@ const Home: React.FC = () => {
 
   return (
     <Container maxWidth="lg">
+      <DevelopmentNoticeModal />
       <Fade in timeout={800}>
         <Box sx={{ py: 4 }}>
           <HeroSection elevation={3}>

--- a/frontend/src/pages/Subscription/Subscription.tsx
+++ b/frontend/src/pages/Subscription/Subscription.tsx
@@ -21,7 +21,7 @@ import AutoStories from '@mui/icons-material/AutoStories';
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import LinearProgress from '@mui/material/LinearProgress';
 import { Pie, Bar } from 'react-chartjs-2';
-
+import SubscriptionNoticeModal from '../../components/DevelopmentModals/SubscriptionNoticeModal';
 const PricingCard = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(4),
   height: '100%',
@@ -87,6 +87,7 @@ const Subscription: React.FC = () => {
 
   return (
     <Container maxWidth="lg">
+      <SubscriptionNoticeModal />
       <Box sx={{ py: 6 }}>
         {/* Hero Section */}
         <Box sx={{ textAlign: 'center', mb: 8 }}>


### PR DESCRIPTION
Added a notice that the site is in development to the home page, and another one letting users know to use a test card, and that they will not be charged while the site is in development. 
